### PR TITLE
Order of metadata fields in search result

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -68,24 +68,24 @@ class CatalogController < ApplicationController
     config.add_index_field solr_name("title", :stored_searchable), label: "Title", itemprop: 'name', if: false
     config.add_index_field solr_name("description", :stored_searchable), itemprop: 'description', helper_method: :iconify_auto_link
     config.add_index_field solr_name("keyword", :stored_searchable), itemprop: 'keywords', link_to_search: solr_name("keyword", :facetable)
-    config.add_index_field solr_name("subject", :stored_searchable), itemprop: 'about', link_to_search: solr_name("subject", :facetable)
+    # config.add_index_field solr_name("subject", :stored_searchable), itemprop: 'about', link_to_search: solr_name("subject", :facetable)
     config.add_index_field solr_name("creator", :stored_searchable), itemprop: 'creator', link_to_search: solr_name("creator", :facetable)
     config.add_index_field solr_name("contributor", :stored_searchable), itemprop: 'contributor', link_to_search: solr_name("contributor", :facetable)
-    config.add_index_field solr_name("proxy_depositor", :symbol), label: "Depositor", helper_method: :link_to_profile
-    config.add_index_field solr_name("depositor"), label: "Owner", helper_method: :link_to_profile
+    # config.add_index_field solr_name("proxy_depositor", :symbol), label: "Depositor", helper_method: :link_to_profile
+    # config.add_index_field solr_name("depositor"), label: "Owner", helper_method: :link_to_profile
     config.add_index_field solr_name("publisher", :stored_searchable), itemprop: 'publisher', link_to_search: solr_name("publisher", :facetable)
-    config.add_index_field solr_name("based_near_label", :stored_searchable), itemprop: 'contentLocation', link_to_search: solr_name("based_near_label", :facetable)
-    config.add_index_field solr_name("language", :stored_searchable), itemprop: 'inLanguage', link_to_search: solr_name("language", :facetable)
-    config.add_index_field solr_name("date_uploaded", :stored_sortable, type: :date), itemprop: 'datePublished', helper_method: :human_readable_date
-    config.add_index_field solr_name("date_modified", :stored_sortable, type: :date), itemprop: 'dateModified', helper_method: :human_readable_date
+    # config.add_index_field solr_name("based_near_label", :stored_searchable), itemprop: 'contentLocation', link_to_search: solr_name("based_near_label", :facetable)
+    # config.add_index_field solr_name("language", :stored_searchable), itemprop: 'inLanguage', link_to_search: solr_name("language", :facetable)
+    # config.add_index_field solr_name("date_uploaded", :stored_sortable, type: :date), itemprop: 'datePublished', helper_method: :human_readable_date
+    # config.add_index_field solr_name("date_modified", :stored_sortable, type: :date), itemprop: 'dateModified', helper_method: :human_readable_date
     config.add_index_field solr_name("date_created", :stored_searchable), itemprop: 'dateCreated'
-    config.add_index_field solr_name("rights_statement", :stored_searchable), helper_method: :rights_statement_links
-    config.add_index_field solr_name("license", :stored_searchable), helper_method: :license_links
+    # config.add_index_field solr_name("rights_statement", :stored_searchable), helper_method: :rights_statement_links
+    # config.add_index_field solr_name("license", :stored_searchable), helper_method: :license_links
     config.add_index_field solr_name("resource_type", :stored_searchable), label: "Resource Type", link_to_search: solr_name("resource_type", :facetable)
-    config.add_index_field solr_name("file_format", :stored_searchable), link_to_search: solr_name("file_format", :facetable)
-    config.add_index_field solr_name("identifier", :stored_searchable), helper_method: :index_field_link, field_name: 'identifier'
-    config.add_index_field solr_name("embargo_release_date", :stored_sortable, type: :date), label: "Embargo release date", helper_method: :human_readable_date
-    config.add_index_field solr_name("lease_expiration_date", :stored_sortable, type: :date), label: "Lease expiration date", helper_method: :human_readable_date
+    # config.add_index_field solr_name("file_format", :stored_searchable), link_to_search: solr_name("file_format", :facetable)
+    # config.add_index_field solr_name("identifier", :stored_searchable), helper_method: :index_field_link, field_name: 'identifier'
+    # config.add_index_field solr_name("embargo_release_date", :stored_sortable, type: :date), label: "Embargo release date", helper_method: :human_readable_date
+    # config.add_index_field solr_name("lease_expiration_date", :stored_sortable, type: :date), label: "Lease expiration date", helper_method: :human_readable_date
     config.add_index_field solr_name("degree", :stored_searchable), label: "Degree"
     config.add_index_field solr_name("department", :stored_searchable), label: "Department"
 
@@ -94,21 +94,22 @@ class CatalogController < ApplicationController
     config.add_show_field solr_name("title", :stored_searchable)
     config.add_show_field solr_name("description", :stored_searchable)
     config.add_show_field solr_name("keyword", :stored_searchable)
-    config.add_show_field solr_name("subject", :stored_searchable)
     config.add_show_field solr_name("creator", :stored_searchable)
     config.add_show_field solr_name("contributor", :stored_searchable)
     config.add_show_field solr_name("publisher", :stored_searchable)
+    config.add_show_field solr_name("date_created", :stored_searchable)
+    config.add_show_field solr_name("degree", :stored_searchable), label: "Degree"
+    config.add_show_field solr_name("department", :stored_searchable), label: "Department"
+    config.add_show_field solr_name("format", :stored_searchable)
+    config.add_show_field solr_name("identifier", :stored_searchable)
+    config.add_show_field solr_name("subject", :stored_searchable)
     config.add_show_field solr_name("based_near_label", :stored_searchable)
     config.add_show_field solr_name("language", :stored_searchable)
     config.add_show_field solr_name("date_uploaded", :stored_searchable)
     config.add_show_field solr_name("date_modified", :stored_searchable)
-    config.add_show_field solr_name("date_created", :stored_searchable)
     config.add_show_field solr_name("rights_statement", :stored_searchable)
     config.add_show_field solr_name("license", :stored_searchable)
     config.add_show_field solr_name("resource_type", :stored_searchable), label: "Resource Type"
-    config.add_show_field solr_name("format", :stored_searchable)
-    config.add_show_field solr_name("identifier", :stored_searchable)
-
     # "fielded" search configuration. Used by pulldown among other places.
     # For supported keys in hash, see rdoc for Blacklight::SearchFields
     #

--- a/spec/features/etd_search_meta_order_spec.rb
+++ b/spec/features/etd_search_meta_order_spec.rb
@@ -1,0 +1,91 @@
+require 'rails_helper'
+include Warden::Test::Helpers
+
+# NOTE: If you generated more than one work, you have to set "js: true"
+RSpec.feature 'Create a Etd', js: false do
+  context 'a logged in user' do
+    let(:user_attributes) do
+      { email: 'test@example.com' }
+    end
+    let(:user) do
+      User.new(user_attributes) { |u| u.save(validate: false) }
+    end
+    let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
+    let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
+    let(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
+
+    before do
+      DatabaseCleaner.clean
+      ActiveFedora::Cleaner.clean!
+      # Create a single action that can be taken
+      Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+
+      # Grant the user access to deposit into the admin set.
+      Hyrax::PermissionTemplateAccess.create!(
+        permission_template_id: permission_template.id,
+        agent_type: 'user',
+        agent_id: user.user_key,
+        access: 'deposit'
+      )
+      login_as user
+    end
+
+    scenario do
+      visit '/dashboard'
+      click_link "Works"
+      click_link "Add new work"
+
+      # If you generate more than one work uncomment these lines
+      # choose "payload_concern", option: "Etd"
+      # click_button "Create work"
+
+      expect(page).to have_content "Add New Etd"
+      click_link "Files" # switch tab
+      expect(page).to have_content "Add files"
+      expect(page).to have_content "Add folder"
+      within('span#addfiles') do
+        attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/image.jp2", visible: false)
+        attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/jp2_fits.xml", visible: false)
+      end
+      click_link "Descriptions" # switch tab
+
+      fill_in('Title', with: 'My Test Work')
+      fill_in('Abstract or Summary', with: 'This is an abstract, this abstract is a Description of the project')
+      fill_in('Creator', with: 'Doe, Jane')
+      fill_in('Contributor', with: 'Robert Brown')
+      fill_in('Publisher', with: 'WPI')
+      fill_in('Keyword', with: 'testing_keyword')
+      fill_in('Subject', with: 'subject_area')
+      fill_in('Date Created', with: '1999-09-09')
+      fill_in('Degree', with: 'MS')
+      fill_in('Department', with: 'ECE')
+      select('In Copyright', from: 'Rights statement')
+
+      # With selenium and the chrome driver, focus remains on the
+      # select box. Click outside the box so the next line can't find
+      # its element
+      find('body').click
+      choose('etd_visibility_open')
+      check('agreement')
+
+      click_on('Save')
+      click_on('Go')
+      save_and_open_page
+      results = page.find('div', :id => 'search-results')
+      div = results.find('div', :class => 'metadata')
+      dl = div.find('dl', :class => 'dl-horizontal')
+
+      expect(dl).to have_content 'Date Created'
+      expect(dl).to have_content('Description' )
+      expect(dl).to have_content('Creator')
+      expect(dl).to have_content('Contributor')
+      expect(dl).to have_content('Publisher')
+      expect(dl).to have_content('Keyword')
+      expect(dl).not_to have_content('Subject')
+      expect(dl).to have_content('Date')
+      expect(dl).to have_content('Degree')
+      expect(dl).to have_content('Department')
+
+    end
+  end
+end


### PR DESCRIPTION
resolves #32 changed which metadata fields display in the search results page and what order they display in. I was given the order by Aaron Neslin.

The New Order:
description, keyword, creator, contributor, publisher, date created, resource type, degree, department