### PR TITLE
Add redis for streaming notification

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ group :production, :development, :test do
   # add mysql for prod envs
   gem 'mysql2', '< 0.5'
   # Use Redis adapter to run Action Cable in production
-  # gem 'redis', '~> 4.0'
+  gem 'redis', '~> 4.0'
   # Use ActiveModel has_secure_password
   # gem 'bcrypt', '~> 3.1.7'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -957,6 +957,7 @@ DEPENDENCIES
   puma (~> 3.7)
   rack-attack
   rails (~> 5.1.6.1)
+  redis (~> 4.0)
   riiif (~> 2.0)
   rsolr (>= 1.0)
   rspec-activemodel-mocks

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,5 +17,6 @@ module DigitalWpi
     # -- all .rb files in that directory are automatically loaded.
 
     config.middleware.use Rack::Attack
+    config.eager_load_paths << Rails.root.join('lib')
   end
 end

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -6,5 +6,5 @@ test:
 
 production:
   adapter: redis
-  url: redis://localhost:6379/1
+  url: redis://<%= ENV['REDIS_HOST'] %>:6379/1
   channel_prefix: wpirepo_production


### PR DESCRIPTION
Fixes #215. Jobs were failing with couple of errors. 1. Redis Gem not found and 2. ActiveJob Deserialization Error. After some research, I uncommented redis Gem in Gemfile. After fixing this, I encountered few more error. Had to change redis host for cable from localhost to Redis Host and since we enabled Eager Load, we also need to load the libraries.

I had to run ```sudo bundle install``` to fix the second issue, because there were many missing gems. Probably because of our recent upgrade to rails 5.1.6.1.