### PR TITLE
ActionView monkey patch

### DIFF
--- a/config/initializers/formats_filter.rb
+++ b/config/initializers/formats_filter.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+# Monkey patch as a work around for upgrading ActionView to 5.1.6.2 which
+# breaks our app.
+# Delete this file after we upgrade ActionView
+
+ActionDispatch::Request.prepend(Module.new do
+  def formats
+    super().select do |format|
+      format.symbol || format.ref == "*/*"
+    end
+  end
+end)


### PR DESCRIPTION
Monkey patch as a work around for upgrading ActionView to 5.1.6.2 which breaks our app. 
Fixes #209 