### PR TITLE
Added honey pot to fight spam

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,7 @@ group :production, :development, :test do
   gem 'devise-multi_auth', git: 'https://github.com/DigitalWPI/devise-multi_auth', branch: 'rails-5-1'
   gem 'hydra-role-management'
   gem 'hyrax', git: 'https://github.com/samvera/hyrax.git', tag: 'v2.5.0'
+  gem 'honeypot-captcha'
   gem 'jquery-rails'
   gem 'lograge'
   gem 'logstash-event'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -401,6 +401,7 @@ GEM
     hashie (3.6.0)
     hiredis (0.6.3)
     honeybadger (4.2.2)
+    honeypot-captcha (1.0.1)
     htmlentities (4.3.4)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
@@ -952,6 +953,7 @@ DEPENDENCIES
   fcrepo_wrapper
   ffaker
   honeybadger (~> 4.0)
+  honeypot-captcha
   hydra-role-management
   hyrax!
   jbuilder (~> 2.5)

--- a/app/views/hyrax/contact_form/new.html.erb
+++ b/app/views/hyrax/contact_form/new.html.erb
@@ -1,0 +1,50 @@
+<div class="alert alert-info">
+  <%= render 'directions' %>
+</div>
+
+<h1>
+    <%= t('hyrax.contact_form.header') %>
+</h1>
+
+<% if user_signed_in? %>
+  <% nm = current_user.name %>
+  <% em = current_user.email %>
+<% else %>
+  <% nm = '' %>
+  <% em = '' %>
+<% end %>
+
+<%= form_for @contact_form, url: hyrax.contact_form_index_path,
+                            html: { class: 'form-horizontal', honeypot: true } do |f| %>
+  <%= f.text_field :contact_method, class: 'hide' %>
+  <div class="form-group">
+    <%= f.label :category, t('hyrax.contact_form.type_label'), class: "col-sm-2 control-label" %>
+    <% issue_types = Hyrax::ContactForm.issue_types_for_locale.dup %>
+    <% issue_types.unshift([t('hyrax.contact_form.select_type'), nil]) %>
+    <div class="col-sm-10">
+      <%= f.select 'category', options_for_select(issue_types), {}, {class: 'form-control', required: true } %>
+    </div>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :name, t('hyrax.contact_form.name_label'), class: "col-sm-2 control-label" %>
+    <div class="col-sm-10"><%= f.text_field :name, value: nm, class: 'form-control', required: true %></div>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :email, t('hyrax.contact_form.email_label'), class: "col-sm-2 control-label" %>
+    <div class="col-sm-10"><%= f.text_field :email, value: em, class: 'form-control', required: true %></div>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :subject, t('hyrax.contact_form.subject_label'), class: "col-sm-2 control-label" %>
+    <div class="col-sm-10"><%= f.text_field :subject, class: 'form-control', required: true %></div>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :message, t('hyrax.contact_form.message_label'), class: "col-sm-2 control-label" %>
+    <div class="col-sm-10"><%= f.text_area :message, rows: 4, class: 'form-control', required: true %></div>
+  </div>
+
+  <%= f.submit value: t('hyrax.contact_form.button_label'), class: "btn btn-primary" %>
+<% end %>


### PR DESCRIPTION
Fixes #219.

Instead using Google's Recaptcha, we could use Honeypot which adds an invisible form field that most bots try to fill and the application rejects all requests that have the invisible field populated there by fighting spam. Also, we should be okay as we have rack attack as well