### PR TITLE
update endnote citation url

### DIFF
--- a/app/views/hyrax/base/_citations.html.erb
+++ b/app/views/hyrax/base/_citations.html.erb
@@ -1,0 +1,13 @@
+<div class="citations">
+    <% if Hyrax.config.citations? %>
+      <%= link_to "Citations", hyrax.citations_work_path(presenter), id: 'citations', class: 'btn btn-default' %>
+    <% end %>
+    <div class="btn-group">
+      <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        <%= t('.header') %> <span class="caret"></span>
+      </button>
+      <ul class="dropdown-menu">
+        <li><%= link_to 'EndNote', polymorphic_path([main_app, presenter], format: 'endnote') %></li>
+      </ul>
+    </div>
+</div>

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -68,7 +68,7 @@ Hyrax.config do |config|
   # config.temp_file_base = '/home/developer1'
 
   # Hostpath to be used in Endnote exports
-  # config.persistent_hostpath = 'http://localhost/files/'
+  config.persistent_hostpath = 'https://' + ENV["SERVERNAME"] + '/show/'
 
   # If you have ffmpeg installed and want to transcode audio and video set to true
   config.enable_ffmpeg = true
@@ -205,7 +205,7 @@ Hyrax.config do |config|
   # If you use a multi-server architecture, this MUST be a shared volume.
   # config.working_path = Rails.root.join( 'tmp', 'uploads')
   config.working_path = Pathname.new(ENV["NFS_DIR"]+ '/')  + 'rails' + 'uploads'
-  
+
   # Should the media display partial render a download link?
   # config.display_media_download_link = true
 


### PR DESCRIPTION
Fixes #229. We have three options for citations. Endnote, Zotero, mendeley. This feature was not a requirement and there is some further configuration for Zotero and Mendeley citations to work. Deleting them for now and have fixed the endnote export url.