### PR TITLE
added contact us/updated team members

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -3,6 +3,7 @@
     <div class="navbar-text text-left">
         <p><%= t('hyrax.footer.service_html') %></p>
         <p><%= t('hyrax.product_name') %> v<%= Hyrax::VERSION %></p>
+        <p><%= mail_to "digitalwpi@wpi.edu", "Contact Us"%></p>
     </div>
     <div class="navbar-right">
       <div class="collapse navbar-collapse" id="top-navbar-collapse">

--- a/app/views/static/about-page.html.erb
+++ b/app/views/static/about-page.html.erb
@@ -60,16 +60,18 @@
             <p>The Library is responsible for Digital WPI content selection and curation, including digitization and submission; metadata, discovery, and analytics; and user experience.</p>
             <p>Information Technology is responsible for Digital WPI’s technical implementation, authentication, security, and integration with other WPI systems and workflows as part of our digital campus ecosystem.</p>
             <ul>
-                <li>Bob Brown, Director, Web Applications Development group, Information Technology (Steering Committee)</li>
+
                 <li>Arthur Carlson, Assistant Director, Archives & Special Collections, Gordon Library (Steering Committee)</li>
                 <li>Lori Ostapowicz Critz, Associate Director, Library Academic Strategies, Gordon Library (Steering Committee)</li>
                 <li>Anna Gold, University Librarian, Gordon Library (Steering Committee)</li>
                 <li>Derek Murphy, Web Applications Developer, Information Technology</li>
                 <li>Emily Ping O’Brien, Digital Programs and Archives Assistant, Gordon Library</li>
-                <li>Zhimin Cheng, Librarian for Core Systems and Digital Repository Administration</li>
+                <li>Zhimin Chen, Librarian for Core Systems and Digital Repository Administration, Gordon Library</li>
+                <li>Andy Whalen, Web Applications Developer, Information Technology (Steering Committee)</li>
             </ul>
             <p>Previous contributors and team members:</p>
             <ul>
+                <li>Bob Brown, Director, Web Applications Development group, Information Technology (2018-2020)</li>
                 <li>Aaron Neslin, Digital Academic Strategies and Metadata Librarian, Gordon Library (2018-2019)</li>
                 <li>Alfred Scott, Systems Developer, Information Technology (2018-2019)</li>
                 <li>Anna Newman, Digital Academic Strategies Librarian, Gordon Library</li>


### PR DESCRIPTION
To fix #281 
**Expect to see **
- Footer: Contact us on the left of footer page (send email to digitalwpi@wpi.edu)
- About page: 
   -- Move Bob's information to Previous contributors and team members section;
   -- Fix typo in Jimmy's last name
   -- Add Andy's information