### PR TITLE
Using WPI's alternate title and not alternative title from Hyrax 3

### DIFF
--- a/app/forms/hyrax/etd_form.rb
+++ b/app/forms/hyrax/etd_form.rb
@@ -4,6 +4,7 @@ module Hyrax
   # Generated form for Etd
   class EtdForm < Hyrax::Forms::WorkForm
     self.model_class = ::Etd
+    self.terms -= [:alternative_title]
     self.terms += [:resource_type, :degree, :department, :alternate_title]
     self.terms += [:advisor, :orcid, :committee, :defense_date, :year, :center]
     self.terms += [:funding, :sponsor, :institute, :school, :award, :includes]

--- a/app/forms/hyrax/generic_work_form.rb
+++ b/app/forms/hyrax/generic_work_form.rb
@@ -4,6 +4,7 @@ module Hyrax
   # Generated form for GenericWork
   class GenericWorkForm < Hyrax::Forms::WorkForm
     self.model_class = ::GenericWork
+    self.terms -= [:alternative_title]
     self.terms += [:resource_type, :award, :includes, :alternate_title]
     self.terms += [:digitization_date, :series, :event, :year]
     self.terms += [:extent, :school]

--- a/app/forms/hyrax/student_work_form.rb
+++ b/app/forms/hyrax/student_work_form.rb
@@ -4,6 +4,7 @@ module Hyrax
   # Generated form for StudentWork
   class StudentWorkForm < Hyrax::Forms::WorkForm
     self.model_class = ::StudentWork
+    self.terms -= [:alternative_title]
     self.terms += [:resource_type, :award, :includes, :alternate_title]
     self.terms += [:advisor, :sponsor, :center, :year]
     self.terms += [:funding, :institute, :sdg, :school, :major]

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -61,10 +61,6 @@ class SolrDocument
     self[Solrizer.solr_name('identifier')]
   end
 
-  def alternative_title
-    self[Solrizer.solr_name('alternative_title')]
-  end
-
   def alternate_title
     self[Solrizer.solr_name('alternate_title')]
   end


### PR DESCRIPTION
Hyrax 3 introduced alternative_title while this was already in use by WPI as alternate_title. 
Both definitions now exist in the model (alternative_title from Hyrax3 code and alternate_title from the digitalwpi code), but we will continue to use alternate_title in the form and in the views, and hide alternative_title. The main reason for holding onto alternate_title is so we don't have to re-index all of the data in solr and move alternate title to alternative_title. 

Note: This fix should hopefully be in place for production. If it isn't this may lead to confusion, as 
* the form will likely have two fields called alternate title and alternative title. 
* In fedora, both of these fields are saved using the same DC term, so one form field value may overwrite the other in Fedora.
It would be good to roll this out to test asap, test with libraries that everything is working as intended and then roll it out to production, if it isn't already there.