### PR TITLE
Fix all fields ignoring other fields

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -159,7 +159,7 @@ class CatalogController < ApplicationController
     # This one uses all the defaults set by the solr request handler. Which
     # solr request handler? The one set in config[:default_solr_parameters][:qt],
     # since we aren't specifying it otherwise.
-    config.add_search_field('q', label: 'All Fields') do |field|
+    config.add_search_field('all_fields', label: 'All Fields') do |field|
       all_names = config.show_fields.values.map(&:field).join(" ")
       title_name = solr_name("title", :stored_searchable)
       field.solr_parameters = {


### PR DESCRIPTION
fixes https://github.com/antleaf/wpi-repository-project/issues/93

This was a bug introduced in PR https://github.com/DigitalWPI/digitalwpi/pull/444/

Fixing the configuration fixes the behavior, but the original issue reported in https://github.com/antleaf/wpi-repository-project/issues/65 remains. On investigation, the search results in advanced search is a subset of the the main search. The main search has metadata matches + full text matches. Advanced search only has metadata matches. It also needs to search the field `all_text_timv`