### PR TITLE
Feature/65 remove full text in advanced search

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -172,6 +172,7 @@ class CatalogController < ApplicationController
         qf: "#{all_names} file_format_tesim all_text_timv",
         pf: title_name.to_s
       }
+      field.include_in_advanced_search = false
     end
 
     # Now we see how to over-ride Solr request handler defaults, in this

--- a/app/views/advanced/_advanced_search_help.html.erb
+++ b/app/views/advanced/_advanced_search_help.html.erb
@@ -9,7 +9,7 @@
       <li>Select "match any" to find at least one field.
       </li>
 
-      <li>"Full text" option searches within document files.</li>
+      <!-- <li>"Full text" option searches within document files.</li> -->
 
       <li>Use quotation marks to search as a phrase.
 


### PR DESCRIPTION
As a temporary solution, we have removed full text from advanced search until we find a solution for https://github.com/antleaf/wpi-repository-project/issues/65