### PR TITLE
Remove all fields from advanced search

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -172,6 +172,7 @@ class CatalogController < ApplicationController
         qf: "#{all_names} file_format_tesim all_text_timv",
         pf: title_name.to_s
       }
+      field.include_in_advanced_search = false
     end
 
     # Now we see how to over-ride Solr request handler defaults, in this


### PR DESCRIPTION
This is replaced by `All fields (no full text)`