### PR TITLE
Automatically process embargo setting in importer

### DIFF
--- a/app/models/concerns/bulkrax/has_local_processing.rb
+++ b/app/models/concerns/bulkrax/has_local_processing.rb
@@ -4,5 +4,28 @@ module Bulkrax::HasLocalProcessing
   # This method is called during build_metadata
   # add any special processing here, for example to reset a metadata property
   # to add a custom property from outside of the import data
-  def add_local; end
+  def add_local
+    parsed_metadata_for_embargo
+  end
+
+
+  def parsed_metadata_for_embargo
+    if record["embargo"].to_s.downcase == "true"
+      parsed_metadata["visibility"] = "embargo"
+      parsed_metadata["embargo_release_date"] = record["embargo_release_date"]
+      parsed_metadata["visibility_during_embargo"] = embargo_visibility(record["visibility_during_embargo"])
+      parsed_metadata["visibility_after_embargo"] = embargo_visibility(record["visibility_after_embargo"])
+    end
+  end
+
+  def embargo_visibility(visibility)
+    case visibility.to_s.downcase
+    when 'private'
+      'restricted'
+    when 'wpi'
+      'authenticated'
+    else
+      'open'
+    end
+  end
 end


### PR DESCRIPTION
fixes https://github.com/antleaf/wpi-repository-project/issues/53

CSV files should be these Embargo metadata fields:
embargo (true/false)
embargo_release_date (should be in `%Y-%m-%d` format)
visibility_during_embargo (visibility during embargo: private/public/wpi)
visibility_after_embargo (visibility after embargo expiration: private/public/wpi)